### PR TITLE
Update traveler and extract overlap count

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN git clone https://github.com/nawrockie/epn-test.git && cd epn-test && git ch
 RUN git clone https://github.com/nawrockie/ribotyper-v1.git && cd ribotyper-v1 && git checkout 4cd7fe30f402edfa4669383a46d603c60ba6f608
 
 # Install Traveler
-RUN git clone https://github.com/davidhoksza/traveler.git && cd traveler && git checkout 0912ed5daab09bb3c38630efaf3643ea38b02dbe
+RUN git clone https://github.com/davidhoksza/traveler.git && cd traveler && git checkout 82ee9f58238f856d128d4b44d9999a509edebdfe
 RUN cd $RNA/traveler/src && make build
 
 # Setup environmental variables


### PR DESCRIPTION
We want the overlap information for the RNAcentral pipeline. Currently,
the only way to get that is to parse the log that traveler produces in
verbose mode. To do that, this saves the log file alongside the other
output files and then parses it and creates a .overlaps file with a
single line that is the number of overlaps.